### PR TITLE
Mention QUIC-MP

### DIFF
--- a/draft-meynell-panrg-scion-research-questions.md
+++ b/draft-meynell-panrg-scion-research-questions.md
@@ -41,6 +41,7 @@ author:
 
 normative:
   RFC9217:
+  I-D.ietf-quic-multipath:
   I-D.scion-cp:
     title: SCION Control Plane
     date: 2023
@@ -287,6 +288,7 @@ There are some nuances: Usually the server's API will store the initial address 
 
 * IPv6 in the Data Plane
 * SCION-IP translation
+* How can we interface with QUIC Multipath {{I-D.ietf-quic-multipath}}?
 
 # Implications of Path Awareness for the Transport and Application Layers
 


### PR DESCRIPTION
Mention QUIC-MP because it appears now to be compatible with SCION by allowing multiple path per 4-tuple.

Contributes to #8 